### PR TITLE
Use pydantic 2 with v1 sub-package.

### DIFF
--- a/stardist/environment.yml
+++ b/stardist/environment.yml
@@ -7,4 +7,4 @@ dependencies:
   - tensorflow-gpu
   - stardist
   - wandb
-  - pydantic==1.* # v2 not compatible at all
+  - pydantic

--- a/stardist/runstardist/config.py
+++ b/stardist/runstardist/config.py
@@ -1,7 +1,7 @@
 import logging
 from pathlib import Path
 
-from pydantic import BaseModel, Field, validator  # pylint: disable=no-name-in-module
+from pydantic.v1 import BaseModel, Field, validator  # pylint: disable=no-name-in-module
 from stardist import gputools_available
 
 from runstardist.utils import check_models, load_config


### PR DESCRIPTION
Hi,

Thank you for the amazing pre-trained models and all the work you put into making them easily available!

I was hoping that we can simply bump pydantic to version 2 and use `pydantic.v1` inside go-nuclear. This would allow me to make use of pydantic2 features in my own config files :nerd_face: 

Note: I did not run any tests with this change.

What do you think?

Cheers