### PR TITLE
chore: remove Windows tests and syntactic changes

### DIFF
--- a/.github/workflows/build-and-test-package.yml
+++ b/.github/workflows/build-and-test-package.yml
@@ -9,7 +9,7 @@ jobs:
   test:
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -22,17 +22,6 @@ jobs:
           environment-file: stardist/environment-dev.yml
           activate-environment: run-stardist-dev
           auto-update-conda: true
-
-      - name: Remove duplicate OpenMP runtime on Windows
-        if: runner.os == 'Windows'
-        shell: pwsh
-        run: |
-          # This file is where Intel-MKL puts its OpenMP runtime.
-          # Deleting it here leaves only TensorFlow’s copy, avoiding the dup‐DLL error.
-          $dll = Join-Path $env:CONDA_PREFIX 'Library\bin\libiomp5md.dll'
-          if (Test-Path $dll) {
-            Remove-Item $dll -Force
-          }
 
       - name: Run integration test (via conda run)
         run: conda run -n run-stardist-dev pytest -s stardist/tests/test_integration.py

--- a/.github/workflows/build-and-test-package.yml
+++ b/.github/workflows/build-and-test-package.yml
@@ -19,9 +19,11 @@ jobs:
       - name: Set up Miniconda
         uses: conda-incubator/setup-miniconda@v2
         with:
+          miniconda-version: "latest"
           environment-file: stardist/environment-dev.yml
           activate-environment: run-stardist-dev
           auto-update-conda: true
+          use-mamba: false
 
       - name: Run integration test (via conda run)
         run: conda run -n run-stardist-dev pytest -s stardist/tests/test_integration.py

--- a/.github/workflows/build-and-test-package.yml
+++ b/.github/workflows/build-and-test-package.yml
@@ -2,14 +2,14 @@ name: Build and Test Package
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
 
 jobs:
   test:
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
 
     steps:

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,2 @@
+[format]
+quote-style = "preserve"

--- a/stardist/runstardist/config.py
+++ b/stardist/runstardist/config.py
@@ -69,7 +69,9 @@ class ConfigPredData(BaseModel):
     @validator('target_voxel_size')
     def target_voxel_size_is_valid(cls, v):  # pylint: disable=no-self-argument,no-self-use
         if v is not None:
-            raise NotImplementedError("Please find a `rescale_factor` manually to rescale your data because only nucleus size in absolute pixel matters. Matching voxel size may help PlantSeg but not StarDist.")
+            raise NotImplementedError(
+                "Please find a `rescale_factor` manually to rescale your data because only nucleus size in absolute pixel matters. Matching voxel size may help PlantSeg but not StarDist."
+            )
 
 
 class ConfigConfig3D(BaseModel):
@@ -136,7 +138,9 @@ class ConfigPredStarDist3D(BaseModel):
             elif check_models(v, update_files=False, config_only=False):
                 logger.warning(f"Model is in {path_dir_models}")
             else:
-                raise NotADirectoryError(f"Model directory {v} does not exist, encounterd error when downloading model.")
+                raise NotADirectoryError(
+                    f"Model directory {v} does not exist, encounterd error when downloading model."
+                )
         elif not (values['model_dir'] / v).is_dir():
             raise NotADirectoryError(f"Model {v} does not exist.")
         return v

--- a/stardist/runstardist/dataio/hdf5.py
+++ b/stardist/runstardist/dataio/hdf5.py
@@ -1,4 +1,4 @@
-""" HDF5 IO functions adapted from PlantSeg
+"""HDF5 IO functions adapted from PlantSeg
 
 https://github.com/hci-unihd/plant-seg/blob/master/plantseg/io/h5.py
 """

--- a/stardist/runstardist/dataio/tiff.py
+++ b/stardist/runstardist/dataio/tiff.py
@@ -1,4 +1,4 @@
-""" TIFF IO functions adapted from PlantSeg
+"""TIFF IO functions adapted from PlantSeg
 
 https://github.com/hci-unihd/plant-seg/edit/master/plantseg/io/tiff.py
 """

--- a/stardist/runstardist/evaluate.py
+++ b/stardist/runstardist/evaluate.py
@@ -192,7 +192,9 @@ def get_volume(image, name=None):
         return image
 
 
-def compare_image_pairs(list_segmentation, list_groundtruth, method='ap', name_segmentation=None, name_groundtruth=None, **kwargs):
+def compare_image_pairs(
+    list_segmentation, list_groundtruth, method='ap', name_segmentation=None, name_groundtruth=None, **kwargs
+):
     if len(list_segmentation) != len(list_groundtruth):
         raise ValueError("Segmentation and ground truth must have the same length.")
     list_scores, list_iou_matrix = [], []
@@ -210,7 +212,9 @@ def apply_compare_image_pair(segmentation_groundtruth_pair):
     return compare_image_pair(segmentation, groundtruth, method='ap')
 
 
-def concurrent_basic_compare_image_pairs(list_segmentation, list_groundtruth, method='ap', name_segmentation=None, name_groundtruth=None):
+def concurrent_basic_compare_image_pairs(
+    list_segmentation, list_groundtruth, method='ap', name_segmentation=None, name_groundtruth=None
+):
     if len(list_segmentation) != len(list_groundtruth):
         raise ValueError("Segmentation and ground truth must have the same length.")
     list_scores, list_iou_matrix = [], []

--- a/stardist/runstardist/resources/zoo.yaml
+++ b/stardist/runstardist/resources/zoo.yaml
@@ -2,6 +2,6 @@ generic_plant_nuclei_3D:
   url_weights: https://zenodo.org/records/8432366/files/stardist_weights.h5
   url_rdf: https://zenodo.org/records/8432366/files/rdf.yaml
   resolution: [0.2837 0.1268 0.1268]
-  description: 'A generic 3D StarDist trained to predict the nuclei in plant. Voxel size: (0.1268×0.1268×0.2837 µm^3) (XYZ)'
-  dimensionality: '3D'
-  modality: 'confocal'
+  description: "A generic 3D StarDist trained to predict the nuclei in plant. Voxel size: (0.1268×0.1268×0.2837 µm^3) (XYZ)"
+  dimensionality: "3D"
+  modality: "confocal"

--- a/stardist/setup.py
+++ b/stardist/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 exec(open('runstardist/__version__.py', encoding='utf-8').read())  # pylint: disable=exec-used
 
 setup(
-    name='run-stardist',  # Replace with your own username
+    name='run-stardist',
     version=__version__,  # pylint: disable=undefined-variable
     author='Qin Yu',
     author_email='qin.yu@embl.de',

--- a/stardist/tests/test_integration.py
+++ b/stardist/tests/test_integration.py
@@ -63,6 +63,7 @@ def test_train_then_predict(tmp_path):
     env = os.environ.copy()
     env["KMP_DUPLICATE_LIB_OK"] = "TRUE"
     env["CUDA_VISIBLE_DEVICES"] = ""
+    env["TF_ENABLE_ONEDNN_OPTS"] = "0"
 
     # 1) Train the model (1 epoch, 1 step)
     run_entry("train-stardist", cfg, env)


### PR DESCRIPTION
TensorFlow stopped Windows support since v2.11, and the current best practice is to do WSL. Testing for Linux is enough.